### PR TITLE
:pencil2: cursor-pointer on hamburger in nav

### DIFF
--- a/components/Nav.js
+++ b/components/Nav.js
@@ -20,7 +20,7 @@ export default function Nav() {
           <a className="font-rubik-mono text-xl">Alamo City Hacks</a>
         </Link>
       </div>
-      <label htmlFor="menu-toggle" className="pointer-cursor lg:hidden block"><svg
+      <label htmlFor="menu-toggle" className="cursor-pointer lg:hidden block"><svg
         className="fill-current text-gray-900" xmlns="http://www.w3.org/2000/svg" width="20" height="20"
         viewBox="0 0 20 20">
         <title>menu</title>


### PR DESCRIPTION
I think it's supposed to be `cursor-pointer` instead of `pointer-cursor` so the cursor turns into a pointer when you hover on the mobile nav menu icon